### PR TITLE
Remove generation of import if it's identical to the package name.

### DIFF
--- a/src/Generator.elm
+++ b/src/Generator.elm
@@ -87,6 +87,7 @@ generatePackage version package =
 
         imports =
             package.imports
+                |> Set.remove package.name
                 |> Set.map (String.append "import ")
                 |> Set.insert "import Protobuf.Decode as Decode"
                 |> Set.insert "import Protobuf.Encode as Encode"


### PR DESCRIPTION
Fix for issue #2. This removes the package name from the set of import names that will be generated, to avoid a cyclic import error during Elm compilation.