### PR TITLE
Set `Main` as default package

### DIFF
--- a/src/Mapper.elm
+++ b/src/Mapper.elm
@@ -411,14 +411,11 @@ dependencies fileDict =
 
 packageName : FileDescriptorProto -> String
 packageName descriptor =
-    classify <|
-        if descriptor.package == "" then
-            descriptor.name
-                |> String.Extra.leftOfBack ".proto"
-                |> String.replace "/" "."
+    if descriptor.package == "" then
+        "Main"
 
-        else
-            descriptor.package
+    else
+        classify descriptor.package
 
 
 classify : String -> String


### PR DESCRIPTION
When no `package` is provided, the spec's filename is used to create one. However, when using multiple files, ProtoBuf asumes they all live in the **same** package. This may result in errors like in #5. Therefore, the generator now uses the default package `Main` for `.proto` files that have not explicitly specified a `package`.